### PR TITLE
🧑‍💻 Update README with updated Gradle functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ repositories {
 }
 
 dependencies {
+    // Gradle ≤4.9
     compile "net.shadew:shwutil:1.7.0"
+    // Gradle 4.10+
+    implementation "net.shadew:shwutil:1.7.0"
     // ...
 }
 ```


### PR DESCRIPTION
The README contained an out of date Gradle function in the install instructions that was deprecated back in 4.10 and removed in 7.0.
This adds a line for the new implementation function that is not deprecated while keeping the old one in case anyone happens to be on a legacy version of Gradle.

NOTE: The commit is flagged as unverified as I made this in GitHub Codespaces and it does not have my private GPG key.

Signed-off-by: Quinn Lane <hello@quinnlane.dev>